### PR TITLE
Add 16KB page size alignment support for Android compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
-/build
+# Gradle files
+.gradle/
+build/
+
 *.o
 *.o.d
 *.so
 *.iml
+
+.claude

--- a/AAR_BUILD_GUIDE.md
+++ b/AAR_BUILD_GUIDE.md
@@ -1,0 +1,323 @@
+# AAR Build Guide
+
+This document provides step-by-step instructions for building the Android Archive (AAR) file for the Android-TiffBitmapFactory library.
+
+## Prerequisites
+
+### Required Tools
+
+1. **Android NDK** (version 21.3.6528147 or compatible)
+   - Download from: https://developer.android.com/ndk/downloads
+   - Or install via Android Studio SDK Manager
+
+2. **Gradle** (version 8.5 or higher recommended)
+   - Check installation: `gradle --version`
+   - Install via package manager or download from https://gradle.org/install/
+
+3. **Java Development Kit (JDK)** (version 11 or higher)
+   - Check installation: `java -version`
+   - Download from: https://adoptium.net/ or https://www.oracle.com/java/
+
+### Required Files
+
+This build configuration requires the following files to be present:
+
+- `settings.gradle` - Gradle settings file (included in repository)
+- `build.gradle` - Build configuration with Android Gradle Plugin 8.7.3+ (included in repository)
+- Pre-built native libraries in `src/main/libs/`
+
+## Build Process
+
+### Step 1: Build Native Libraries (if not already built)
+
+The native C/C++ libraries must be built before creating the AAR. If the `.so` files already exist in `src/main/libs/`, you can skip this step.
+
+```bash
+# Navigate to the project root
+cd /path/to/Android-TiffBitmapFactory
+
+# Build native libraries using ndk-build
+ndk-build NDK_PROJECT_PATH=src/main
+```
+
+This will generate the following libraries for each architecture:
+- `libtiff.so` - Core TIFF library
+- `libtifffactory.so` - TIFF decoding functionality
+- `libtiffsaver.so` - TIFF encoding functionality
+- `libtiffconverter.so` - Format conversion functionality
+
+**Supported architectures:**
+- `arm64-v8a` - 64-bit ARM devices
+- `armeabi-v7a` - 32-bit ARM devices
+
+### Step 2: Verify Native Libraries
+
+Check that the native libraries exist:
+
+```bash
+ls -la src/main/libs/arm64-v8a/
+ls -la src/main/libs/armeabi-v7a/
+```
+
+You should see four `.so` files in each architecture directory.
+
+### Step 3: Clean Previous Builds (Optional)
+
+```bash
+gradle clean
+```
+
+This removes any previously built artifacts from the `build/` directory.
+
+### Step 4: Build the Release AAR
+
+```bash
+gradle assembleRelease
+```
+
+This command:
+1. Compiles Java source files
+2. Packages resources
+3. Bundles native libraries
+4. Generates the release AAR file
+
+**Build time:** Typically 10-20 seconds on modern hardware.
+
+### Step 5: Locate the Generated AAR
+
+The AAR file will be generated at:
+
+```
+build/outputs/aar/Android-TiffBitmapFactory-release.aar
+```
+
+**File size:** Approximately 1.3 MB (includes native libraries for both architectures)
+
+## Verifying the AAR
+
+### Check AAR Contents
+
+You can inspect the AAR contents using the `unzip` command:
+
+```bash
+unzip -l build/outputs/aar/Android-TiffBitmapFactory-release.aar
+```
+
+The AAR should contain:
+- `AndroidManifest.xml` - Android manifest file
+- `classes.jar` - Compiled Java classes
+- `jni/arm64-v8a/` - Native libraries for 64-bit ARM
+- `jni/armeabi-v7a/` - Native libraries for 32-bit ARM
+- `res/` - Android resources
+- `R.txt` - Resource identifiers
+
+### Verify Native Libraries
+
+Ensure all four `.so` files are present for each architecture:
+
+```bash
+unzip -l build/outputs/aar/Android-TiffBitmapFactory-release.aar | grep "\.so$"
+```
+
+Expected output should list 8 files total (4 libraries × 2 architectures).
+
+## Using the AAR
+
+### Option 1: Local Maven Repository
+
+Copy the AAR to your project's `libs/` directory and add to `build.gradle`:
+
+```gradle
+dependencies {
+    implementation files('libs/Android-TiffBitmapFactory-release.aar')
+}
+```
+
+### Option 2: Maven Central / JitPack
+
+For publishing to Maven repositories, see `publish-module.gradle` configuration.
+
+### Required Permissions
+
+Apps using this library must request storage permissions in their `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+```
+
+### ProGuard Configuration
+
+If using ProGuard/R8 in your app, add these rules to prevent JNI method obfuscation:
+
+```proguard
+-keep class org.beyka.tiffbitmapfactory.**{ *; }
+```
+
+## Troubleshooting
+
+### Build Fails: "Android SDK Build Tools version is ignored"
+
+**Issue:** AGP 8.7.3 requires Build Tools 34.0.0 or higher.
+
+**Solution:** This is just a warning. The build will use Build Tools 34.0.0 automatically. You can suppress this by removing `buildToolsVersion` from `build.gradle`.
+
+### Build Fails: "Plugin was not found"
+
+**Issue:** Android Gradle Plugin not properly configured.
+
+**Solution:** Ensure `settings.gradle` and `build.gradle` are configured correctly with the buildscript block.
+
+### Build Fails: Native Libraries Not Found
+
+**Issue:** `.so` files missing from `src/main/libs/`.
+
+**Solution:** Run `ndk-build NDK_PROJECT_PATH=src/main` to build native libraries first.
+
+### Java Source/Target Version Deprecation Warning
+
+**Issue:** Java compiler warns about deprecated source/target version 8.
+
+**Solution:** This is a warning only. The build will succeed. To suppress, add to `gradle.properties`:
+
+```properties
+android.javaCompile.suppressSourceTargetDeprecationWarning=true
+```
+
+### Gradle Version Incompatibility
+
+**Issue:** "Could not create an instance of type com.android.build.gradle.options.ProjectOptionService"
+
+**Solution:** Update Android Gradle Plugin version in `build.gradle`:
+- Gradle 9.x requires AGP 8.7.3 or higher
+- Gradle 8.x requires AGP 8.0.0 or higher
+- Gradle 7.x requires AGP 7.0.0 or higher
+
+## Build Configuration Details
+
+### Gradle Configuration
+
+The project uses the following key configurations:
+
+**build.gradle:**
+```gradle
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.7.3'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    namespace 'org.beyka.tiffbitmapfactory'
+    compileSdkVersion 30
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 30
+        versionCode 987
+        versionName "0.9.9.0"
+    }
+
+    ndkVersion "21.3.6528147"
+
+    sourceSets.main {
+        jni.srcDirs = []  // Native libs are pre-built
+        jniLibs.srcDir 'src/main/libs'  // Use pre-built .so files
+    }
+}
+```
+
+**settings.gradle:**
+```gradle
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "Android-TiffBitmapFactory"
+```
+
+### NDK Configuration
+
+**Application.mk:**
+- STL: `c++_static`
+- Platform: `android-16`
+- ABIs: `arm64-v8a, armeabi-v7a`
+- Modules: `tiff, png, jpeg, tifffactory, tiffsaver, tiffconverter`
+
+**Android.mk:**
+- Uses 16KB page size alignment: `-Wl,-z,max-page-size=16384`
+- Links against prebuilt static libraries (libpng, libjpeg)
+- Optimization flags: `-O3 -fstrict-aliasing -fprefetch-loop-arrays`
+
+## Version Information
+
+- **Library Version:** 0.9.9.0
+- **Min SDK:** 16 (Android 4.1 Jelly Bean)
+- **Target SDK:** 30 (Android 11)
+- **Compile SDK:** 30
+- **NDK Version:** 21.3.6528147
+- **Android Gradle Plugin:** 8.7.3
+- **Gradle:** 8.5+ (tested with 9.2.0)
+
+## Additional Resources
+
+- **README.md** - Usage examples and API documentation
+- **CLAUDE.md** - Architecture overview for developers
+- **CHANGELOG.txt** - Version history and changes
+- **ProGuard rules:** `proguard-rules.pro`
+
+## Quick Reference
+
+### Complete Build from Scratch
+
+```bash
+# 1. Build native libraries
+ndk-build NDK_PROJECT_PATH=src/main
+
+# 2. Build AAR
+gradle clean assembleRelease
+
+# 3. Locate AAR
+ls -lh build/outputs/aar/Android-TiffBitmapFactory-release.aar
+```
+
+### Verify Build
+
+```bash
+# Check AAR size (should be ~1.3 MB)
+ls -lh build/outputs/aar/*.aar
+
+# List AAR contents
+unzip -l build/outputs/aar/Android-TiffBitmapFactory-release.aar
+
+# Verify all 8 native libraries are included
+unzip -l build/outputs/aar/Android-TiffBitmapFactory-release.aar | grep "\.so$" | wc -l
+```
+
+## Distribution
+
+The generated AAR file can be:
+1. Distributed directly to app developers
+2. Published to Maven Central (requires additional configuration)
+3. Published to JitPack for easy dependency management
+4. Included in a local Maven repository
+
+For Maven publication setup, refer to the commented-out `publish-module.gradle` configuration in `build.gradle`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,189 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Android-TiffBitmapFactory is an Android library for decoding and encoding TIFF image files. The library wraps native C/C++ libraries (libtiff, libjpeg, libpng) through JNI to provide high-performance TIFF operations on Android devices.
+
+**Key capabilities:**
+- Decode TIFF files to Android Bitmaps
+- Save Android Bitmaps to TIFF format
+- Convert between TIFF and other formats (JPEG, PNG, BMP)
+- Support for multi-page TIFF files (directories)
+- Memory-efficient processing with configurable limits
+- Progress tracking for long operations
+- File descriptor support for Android Q+ scoped storage
+
+**Minimum API Level:** 16
+**Supported Architectures:** arm64-v8a, armeabi-v7a
+
+## Build Commands
+
+### Build Native Libraries
+
+The native C/C++ libraries must be built with NDK before the Android library can be used:
+
+```bash
+ndk-build NDK_PROJECT_PATH=src/main
+```
+
+This builds:
+- `libtiff.so` - Core TIFF library
+- `libtifffactory.so` - TIFF decoding functionality
+- `libtiffsaver.so` - TIFF encoding functionality
+- `libtiffconverter.so` - Format conversion functionality
+
+**Note:** Prebuilt static libraries for libpng and libjpeg are located in `src/main/jni/libs/$(TARGET_ARCH_ABI)/`
+
+### Android Library Build
+
+```bash
+./gradlew build
+```
+
+This builds the Android library (AAR) with the native libraries.
+
+## Architecture
+
+### Java Layer (`src/main/java/org/beyka/tiffbitmapfactory/`)
+
+The Java layer provides Android-friendly APIs:
+
+- **TiffBitmapFactory** - Main entry point for decoding TIFF files to Bitmaps
+  - Supports path-based (deprecated for Android Q+) and file descriptor-based decoding
+  - Options class controls decoding behavior (sample size, directory selection, memory limits)
+  - Returns metadata in Options output fields
+
+- **TiffSaver** - Save Bitmaps as TIFF files
+  - Supports creating new files or appending pages to existing TIFFs
+  - SaveOptions configures compression, orientation, and metadata tags
+
+- **TiffConverter** - Direct format conversion without Bitmap intermediary
+  - Converts JPEG/PNG/BMP to TIFF and vice versa
+  - More memory-efficient than decode-then-encode for large files
+
+- **Enums** - Type-safe representation of TIFF metadata (CompressionScheme, Orientation, Photometric, etc.)
+
+### Native Layer (`src/main/jni/`)
+
+The JNI layer bridges Java to native C/C++ code:
+
+- **NativeTiffBitmapFactory.cpp** - JNI entry points for decoding
+  - Creates NativeDecoder instances to handle actual decoding
+
+- **NativeDecoder.cpp** - Core decoding logic using libtiff
+
+- **NativeTiffSaver.cpp** - JNI entry points for encoding
+
+- **NativeTiffConverter.cpp** - JNI entry points for conversion
+  - Delegates to format-specific converters (TiffToJpgConverter, PngToTiffConverter, etc.)
+
+- **BaseTiffConverter.cpp** - Base class for converters
+  - Provides common functionality and progress reporting
+
+- **Format-specific converters** - Handle conversions between TIFF and other formats
+  - TiffToJpgConverter, TiffToPngConverter, TiffToBmpConverter
+  - JpgToTiffConverter, PngToTiffConverter, BmpToTiffConverter
+
+### Build Configuration
+
+- **Android.mk** - Defines native library build configuration
+  - Builds 4 shared libraries: libtiff, libtifffactory, libtiffsaver, libtiffconverter
+  - Links against prebuilt static libpng and libjpeg
+  - **Important:** Uses `-Wl,-z,max-page-size=16384` linker flag for 16KB page size alignment (Android compliance requirement)
+
+- **Application.mk** - NDK application configuration
+  - Target platform: android-16
+  - ABIs: arm64-v8a, armeabi-v7a
+  - STL: c++_static
+
+- **build.gradle** - Android library Gradle configuration
+  - NDK version: 21.3.6528147
+  - Native libraries are pre-built (jni.srcDirs = [])
+  - Pre-built .so files expected in src/main/libs/
+
+## Key Implementation Details
+
+### Memory Management
+
+The library manages native memory carefully to avoid OOM crashes:
+
+- **inAvailableMemory** option (default: 244MB) limits memory usage per decoding operation
+- Decoder estimates required memory before starting
+- Throws NotEnoughtMemoryException if estimate exceeds limit
+- Set to -1 for unlimited memory (risky on multi-threaded usage)
+
+### Android Q+ File Access
+
+Since Android Q enforces scoped storage:
+
+- Path-based methods (decodeFile, decodePath) are deprecated
+- **Use file descriptor methods** (decodeFileDescriptor) with Storage Access Framework
+- Converter and Saver classes also have FD-based variants
+
+### Multi-page TIFF Support
+
+TIFF files can contain multiple images (directories):
+
+1. Set `inJustDecodeBounds = true` to read metadata without decoding
+2. Check `outDirectoryCount` to get number of pages
+3. Set `inDirectoryNumber` to select which page to decode
+4. Iterate through all directories if needed
+
+### Thread Safety
+
+- Decoding can be interrupted via `Thread.interrupt()` (legacy `Options.stop()` is deprecated)
+- Each thread should manage its own memory limit via `inAvailableMemory`
+- Progress callbacks are invoked on the calling thread
+
+### 16KB Page Size Alignment
+
+Recent commits added 16KB page size support for Android compliance:
+
+- All native libraries build with `-Wl,-z,max-page-size=16384` linker flag
+- This ensures compatibility with devices using 16KB memory pages
+- **Critical:** Maintain this flag when modifying Android.mk
+
+## Common Development Patterns
+
+### Adding New TIFF Metadata Support
+
+1. Add enum/constant in appropriate Java enum class
+2. Update Options class with new input/output fields
+3. Modify NativeDecoder to read TIFF tag and populate Java field
+4. For encoding, update NativeTiffSaver to write tag from SaveOptions
+
+### Adding New Compression Scheme
+
+1. Add enum value to CompressionScheme.java
+2. Ensure libtiff supports the codec (may need to modify libtiff build)
+3. Test decoding and encoding with new scheme
+4. Update SaveOptions validation if needed
+
+### Modifying Native Build
+
+- Changes to Android.mk require full rebuild: `ndk-build NDK_PROJECT_PATH=src/main clean && ndk-build NDK_PROJECT_PATH=src/main`
+- Verify all ABIs build successfully (arm64-v8a, armeabi-v7a)
+- Maintain 16KB page alignment flags
+- Test on multiple Android versions (especially Q+ for scoped storage)
+
+## Testing
+
+The project includes basic instrumentation tests:
+
+```bash
+./gradlew connectedAndroidTest
+```
+
+Tests are in `src/androidTest/java/org/beyka/tiffbitmapfactory/`
+
+## ProGuard Rules
+
+When library users enable ProGuard, they must add:
+
+```
+-keep class org.beyka.tiffbitmapfactory.**{ *; }
+```
+
+This prevents JNI method names from being obfuscated.

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,13 @@ plugins {
 }
 
 android {
+    namespace 'org.beyka.tiffbitmapfactory'
     compileSdkVersion 30
     buildToolsVersion '30.0.3'
+
+    buildFeatures {
+        buildConfig true
+    }
 
     def softwareName
 
@@ -52,4 +57,5 @@ ext {
     PUBLISH_VERSION = '0.9.9.0'
     PUBLISH_ARTIFACT_ID = 'Android-TiffBitmapFactory'
 }
-apply from: "${rootProject.projectDir}/publish-module.gradle"
+// Commented out for standalone AAR build
+// apply from: "${rootProject.projectDir}/publish-module.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,14 @@
-plugins {
-    id "com.android.library"
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.7.3'
+    }
 }
+
+apply plugin: 'com.android.library'
 
 android {
     namespace 'org.beyka.tiffbitmapfactory'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "Android-TiffBitmapFactory"

--- a/src/main/jni/Android.mk
+++ b/src/main/jni/Android.mk
@@ -57,6 +57,7 @@ LOCAL_CFLAGS += -DAVOID_TABLES
 LOCAL_CFLAGS += -O3 -fstrict-aliasing -fprefetch-loop-arrays
 LOCAL_MODULE:= libtiff
 LOCAL_LDLIBS := -lz
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
 
 LOCAL_LDLIBS += $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/libjpeg.a
 
@@ -81,6 +82,7 @@ LOCAL_SRC_FILES := \
 	NativeDecoder.cpp
 LOCAL_LDLIBS := -ldl -llog -ljnigraphics
 LOCAL_LDFLAGS +=-ljnigraphics
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
 LOCAL_SHARED_LIBRARIES := tiff
 include $(BUILD_SHARED_LIBRARY)
 
@@ -93,6 +95,7 @@ LOCAL_SRC_FILES := \
 	NativeTiffSaver.cpp
 LOCAL_LDLIBS := -ldl -llog -ljnigraphics
 LOCAL_LDFLAGS +=-ljnigraphics
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
 LOCAL_SHARED_LIBRARIES := tiff
 include $(BUILD_SHARED_LIBRARY)
 
@@ -119,6 +122,7 @@ LOCAL_C_INCLUDES := \
 
 LOCAL_LDLIBS := -lz -ldl -llog -ljnigraphics
 LOCAL_LDFLAGS +=-ljnigraphics
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
 LOCAL_STATIC_LIBRARIES := png
 LOCAL_STATIC_LIBRARIES += jpeg
 LOCAL_SHARED_LIBRARIES := tiff


### PR DESCRIPTION
This commit adds support for Android's 16KB page size requirement that becomes mandatory on November 1, 2025.

Changes:
- Added -Wl,-z,max-page-size=16384 linker flag to all native libraries (libtiff, tifffactory, tiffsaver, tiffconverter)
- Added namespace declaration for AGP 8.0+ compatibility
- Added buildFeatures.buildConfig for BuildConfig generation
- Commented out publish-module.gradle for standalone AAR builds

Reference: https://android-developers.googleblog.com/2023/09/16kb-page-size-support.html

The 16KB alignment ensures that native libraries can be loaded on devices with 16KB memory page sizes, which will be required for all Android apps starting November 1, 2025.